### PR TITLE
Export header type function

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,12 @@ pub struct Header {
     t: String,
 }
 
+impl Header {
+    pub fn t<'a>(&'a self) -> &'a str {
+        &self.t.as_str()
+    }
+}
+
 #[async_trait]
 pub trait SignatureScheme {
     type Signature;


### PR DESCRIPTION
Header `t` value is private; here's an export for it.