### PR TITLE
Update repo in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Spruce Systems, Inc."]
 edition = "2021"
 license = "Apache-2.0"
 description = "Core library for CACAO traits and data structures"
-repository = "https://github.com/spruceid/cacao/"
+repository = "https://github.com/spruceid/cacao-rs/"
 
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
So that the repo link in crates.io is correct for the next release.