### PR TITLE
Re-export siwe-rs.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,10 @@ repository = "https://github.com/spruceid/cacao/"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]
 eip4361 = ["hex", "ethers-core"]
-zcap = ["ssi"]
-default = ["eip4361", "zcap"]
+default = ["eip4361"]
 
 [dependencies]
-siwe = { version = "0.2" }
+siwe = "0.2"
 iri-string = { version = "0.4", features = ["serde", "serde-std"] }
 chrono = "0.4"
 thiserror = "1.0"
@@ -27,7 +26,6 @@ serde_with = "1.11"
 http = "0.2.5"
 hex = { version = "0.4", optional = true }
 ethers-core = { version = "0.6.2", optional = true }
-ssi = { version = "0.4", optional = true }
 
 [dev-dependencies]
 async-std = { version = "1.10", features = ["attributes"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cacaos"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Spruce Systems, Inc."]
 edition = "2021"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ eip4361 = ["hex", "ethers-core"]
 default = ["eip4361"]
 
 [dependencies]
-siwe = "0.2"
+siwe = { git = "https://github.com/spruceid/siwe-rs.git", rev = "1387ac6" }
 iri-string = { version = "0.4", features = ["serde", "serde-std"] }
 thiserror = "1.0"
 url = "2.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ eip4361 = ["hex", "ethers-core"]
 default = ["eip4361"]
 
 [dependencies]
-siwe = { git = "https://github.com/spruceid/siwe-rs.git", rev = "1387ac6" }
+siwe = "0.3"
 iri-string = { version = "0.4", features = ["serde", "serde-std"] }
 thiserror = "1.0"
 url = "2.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ default = ["eip4361"]
 [dependencies]
 siwe = "0.2"
 iri-string = { version = "0.4", features = ["serde", "serde-std"] }
-chrono = "0.4"
 thiserror = "1.0"
 url = "2.2"
 async-trait = "0.1"
@@ -26,6 +25,12 @@ serde_with = "1.11"
 http = "0.2.5"
 hex = { version = "0.4", optional = true }
 ethers-core = { version = "0.6.2", optional = true }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+chrono = "0.4"
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+chrono = { version = "0.4", features = ["wasmbind"] }
 
 [dev-dependencies]
 async-std = { version = "1.10", features = ["attributes"] }

--- a/src/generic.rs
+++ b/src/generic.rs
@@ -4,16 +4,18 @@ use libipld::{
     cbor::DagCborCodec,
     codec::{Decode, Encode},
 };
+use std::fmt::Debug;
 use std::marker::PhantomData;
 
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct GenericScheme<R, S>(PhantomData<R>, PhantomData<S>);
 
 #[async_trait]
 impl<R, S, P> SignatureScheme for GenericScheme<R, S>
 where
-    R: Representation<Output = P>,
-    S: SignatureType,
+    R: Representation<Output = P> + Debug,
+    S: SignatureType + Debug,
+    S::Signature: Debug,
     S::Payload: Send + Sync,
     S::VerificationMaterial: Send + Sync,
     R::Err: Send + Sync,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+use std::fmt::Debug;
+
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use http::uri::{Authority, InvalidUri};
@@ -10,7 +12,8 @@ use libipld::{
     codec::{Decode, Encode},
     DagCbor, Ipld,
 };
-pub use siwe::TimeStamp;
+pub use siwe;
+use siwe::TimeStamp;
 use thiserror::Error;
 
 pub mod generic;
@@ -104,17 +107,17 @@ pub enum VerificationError {
     NotCurrentlyValid,
 }
 
-#[derive(DagCbor)]
+#[derive(DagCbor, Debug)]
 pub struct BasicSignature<S>
 where
-    S: DagCbor + AsRef<[u8]> + TryFrom<Vec<u8>>,
+    S: DagCbor + Debug + AsRef<[u8]> + TryFrom<Vec<u8>>,
 {
     pub s: S,
 }
 
 impl<S> AsRef<[u8]> for BasicSignature<S>
 where
-    S: DagCbor + AsRef<[u8]> + TryFrom<Vec<u8>>,
+    S: DagCbor + Debug + AsRef<[u8]> + TryFrom<Vec<u8>>,
 {
     fn as_ref(&self) -> &[u8] {
         self.s.as_ref()
@@ -123,7 +126,7 @@ where
 
 impl<S> TryFrom<Vec<u8>> for BasicSignature<S>
 where
-    S: DagCbor + AsRef<[u8]> + TryFrom<Vec<u8>>,
+    S: DagCbor + Debug + AsRef<[u8]> + TryFrom<Vec<u8>>,
 {
     type Error = <S as TryFrom<Vec<u8>>>::Error;
     fn try_from(s: Vec<u8>) -> Result<Self, Self::Error> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,6 +105,10 @@ pub enum VerificationError {
     MissingVerificationMaterial,
     #[error("Not Currently Valid")]
     NotCurrentlyValid,
+    #[error("Domain does not match")]
+    DomainMismatch,
+    #[error("Nonce does noe match")]
+    NonceMismatch,
 }
 
 #[derive(DagCbor, Debug)]

--- a/src/siwe_cacao.rs
+++ b/src/siwe_cacao.rs
@@ -34,6 +34,8 @@ impl From<SVE> for VerificationError {
             SVE::Crypto(_) | SVE::Signer => Self::Crypto,
             SVE::Serialization(_) => Self::Serialization,
             SVE::Time => Self::NotCurrentlyValid,
+            SVE::DomainMismatch => Self::DomainMismatch,
+            SVE::NonceMismatch => Self::NonceMismatch,
         }
     }
 }

--- a/src/siwe_cacao.rs
+++ b/src/siwe_cacao.rs
@@ -98,6 +98,7 @@ impl From<Message> for Payload {
     }
 }
 
+#[derive(Debug)]
 pub struct SignInWithEthereum;
 #[derive(Debug)]
 pub struct SIWESignature([u8; 65]);

--- a/src/siwe_cacao.rs
+++ b/src/siwe_cacao.rs
@@ -99,6 +99,7 @@ impl From<Message> for Payload {
 }
 
 pub struct SignInWithEthereum;
+#[derive(Debug)]
 pub struct SIWESignature([u8; 65]);
 
 impl std::ops::Deref for SIWESignature {


### PR DESCRIPTION
`siwe`'s `Message` among other structs is part of the external API of this crate, so `siwe` should be re-exported so that dependency clashes can easily be avoided.

Also removed `ssi` and the `zcap` feature as they aren't used, and added a `Debug` impl.