### PR TITLE
remove ethers-core dep

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cacaos"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Spruce Systems, Inc."]
 edition = "2021"
 license = "Apache-2.0"
@@ -10,13 +10,12 @@ repository = "https://github.com/spruceid/cacao-rs/"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]
-eip4361 = ["hex", "ethers-core"]
+eip4361 = ["hex"]
 default = ["eip4361"]
 
 [dependencies]
-# siwe = "0.4.2"
-siwe = { git = "https://github.com/spruceid/siwe-rs.git" }
-iri-string = { version = "0.6", features = ["serde"] }
+siwe = "0.4.2"
+iri-string = { version = "0.4", features = ["serde", "serde-std"] }
 thiserror = "1.0"
 url = "2.2"
 async-trait = "0.1"
@@ -26,7 +25,6 @@ serde_with = "2.0"
 time = { version = "0.3", features = ["parsing", "formatting"] }
 http = "0.2.5"
 hex = { version = "0.4", optional = true }
-ethers-core = { version = "0.17.0", optional = true }
 
 [dev-dependencies]
 async-std = { version = "1.10", features = ["attributes"] }

--- a/src/siwe_cacao.rs
+++ b/src/siwe_cacao.rs
@@ -1,6 +1,5 @@
 use super::{Representation, SignatureScheme, CACAO};
 use async_trait::async_trait;
-use ethers_core::{types::H160, utils::to_checksum};
 use hex::FromHex;
 use http::uri::Authority;
 use iri_string::{
@@ -14,7 +13,7 @@ use libipld::{
     DagCbor,
 };
 pub use siwe;
-use siwe::{Message, TimeStamp, VerificationError as SVE, Version as SVersion};
+use siwe::{eip55, Message, TimeStamp, VerificationError as SVE, Version as SVersion};
 use std::fmt::Debug;
 use std::io::{Read, Seek, Write};
 use thiserror::Error;
@@ -268,13 +267,9 @@ impl From<Message> for Payload {
     fn from(m: Message) -> Self {
         Self {
             domain: m.domain,
-            iss: format!(
-                "did:pkh:eip155:{}:{}",
-                m.chain_id,
-                to_checksum(&H160(m.address), None)
-            )
-            .parse()
-            .unwrap(),
+            iss: format!("did:pkh:eip155:{}:{}", m.chain_id, eip55(&m.address))
+                .parse()
+                .unwrap(),
             statement: m.statement,
             aud: m.uri,
             version: m.version.into(),


### PR DESCRIPTION
now that `eip55` is exposed by `siwe`, we can remove the dependancy on `ethers-core`