### PR TITLE
updates siwe and iri-string dependancy versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cacaos"
-version = "0.4.1"
+version = "0.5.0"
 authors = ["Spruce Systems, Inc."]
 edition = "2021"
 license = "Apache-2.0"
@@ -14,8 +14,8 @@ eip4361 = ["hex"]
 default = ["eip4361"]
 
 [dependencies]
-siwe = "0.4.2"
-iri-string = { version = "0.4", features = ["serde", "serde-std"] }
+siwe = "0.5"
+iri-string = { version = "0.6", features = ["serde"] }
 thiserror = "1.0"
 url = "2.2"
 async-trait = "0.1"


### PR DESCRIPTION
#21 updated `siwe` and `ethers-core` such that the resolved version of the `signature` crate was incompatible with the version resolved in the `ssi` crate, [blocking a pr there](https://github.com/spruceid/ssi/pull/450). #22 removed `ethers-core` and reverted the version changes in #21 but `siwe` 0.4.2 still has the same issue. This pr restores the version changes made in #21, once [this pr in `ssi` is merged to update the relevant dependancies](https://github.com/spruceid/ssi/pull/385).