### PR TITLE
Remove dependency on libipld-pb and add Clippy to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,3 +31,9 @@ jobs:
 
     - name: Test
       run: cargo test
+
+    - name: Fmt
+      run: cargo fmt -- --check
+
+    - name: Clippy
+      run: RUSTFLAGS="-Dwarnings" cargo clippy

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cacaos"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Spruce Systems, Inc."]
 edition = "2021"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ thiserror = "1.0"
 url = "2.2"
 async-trait = "0.1"
 serde = "1.0"
-libipld = "0.14"
+libipld = { version = "0.14", default-features = false, features = ["dag-cbor", "derive"]}
 serde_with = "2.0"
 time = { version = "0.3", features = ["parsing", "formatting"] }
 http = "0.2.5"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 use std::fmt::Debug;
 
 use async_trait::async_trait;
-use libipld::{cbor::DagCbor, DagCbor, Ipld};
+use libipld::{cbor::DagCbor, DagCbor};
 pub use siwe;
 
 pub mod siwe_cacao;

--- a/src/siwe_cacao.rs
+++ b/src/siwe_cacao.rs
@@ -21,10 +21,10 @@ use time::OffsetDateTime;
 
 pub type SiweCacao = CACAO<Eip191, Eip4361>;
 
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct Header;
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Payload {
     pub domain: Authority,
     pub iss: UriAbsoluteString,
@@ -39,7 +39,7 @@ pub struct Payload {
     pub resources: Vec<UriString>,
 }
 
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum Version {
     V1 = 1,
 }
@@ -154,7 +154,7 @@ mod payload_ipld {
         where
             R: Read + Seek,
         {
-            TmpPayload::decode(c, r).and_then(|t| Ok(t.try_into()?))
+            TmpPayload::decode(c, r).and_then(|t| t.try_into())
         }
     }
 
@@ -192,7 +192,7 @@ mod payload_ipld {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct Eip4361;
 
 impl Representation for Eip4361 {
@@ -283,7 +283,7 @@ impl From<Message> for Payload {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct SIWESignature([u8; 65]);
 
 impl std::ops::Deref for SIWESignature {
@@ -357,7 +357,7 @@ impl Decode<DagCborCodec> for SIWESignature {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct Eip191;
 
 #[async_trait]
@@ -369,7 +369,7 @@ impl SignatureScheme<Eip4361> for Eip191 {
         sig: &Self::Signature,
     ) -> Result<(), VerificationError> {
         let m: Message = payload.clone().try_into()?;
-        m.verify_eip191(&sig)?;
+        m.verify_eip191(sig)?;
         Ok(())
     }
 }


### PR DESCRIPTION
libipld-pb requires CMake at compile time. Not a big deal but somehow I was too lazy to install it.