### PR TITLE
bump libipld dependancy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ thiserror = "1.0"
 url = "2.2"
 async-trait = "0.1"
 serde = "1.0"
-libipld = "0.14"
+libipld = { version = "0.16", default-features = false, features = ["dag-cbor", "derive", "serde-codec"]}
 serde_with = "2.0"
 time = { version = "0.3", features = ["parsing", "formatting"] }
 http = "0.2.5"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 use std::fmt::Debug;
 
 use async_trait::async_trait;
-use libipld::{cbor::DagCbor, DagCbor, Ipld};
+use libipld::{cbor::DagCbor, DagCbor};
 pub use siwe;
 
 pub mod siwe_cacao;


### PR DESCRIPTION
libipld has been updated, removing a problematic dependancy on `protoc`