### PR TITLE
Webauthn varsig

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ ssi-dids = { git = "https://github.com/spruceid/ssi.git", branch = "feat/ucan-0.
 time = { version = "0.3", features = ["parsing", "formatting", "serde", "macros"] }
 http = "0.2.5"
 hex = { version = "0.4", optional = true }
-varsig = { version = "0.1", path = "./varsig" }
+varsig = { version = "0.1", path = "./varsig", features = ["webauthn"] }
 multidid = { version = "0.1", path = "./multidid" }
 siwe-recap = { version = "0.2" }
 

--- a/varsig/Cargo.toml
+++ b/varsig/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]
 default = ["serde", "webauthn"]
-webauthn = ["serde", "dep:passkey-types", "dep:serde_json", "dep:coset"]
+webauthn = ["serde", "dep:passkey-types", "dep:serde_json", "dep:coset", "dep:multihash"]
 serde = ["dep:serde"]
 
 [dependencies]
@@ -16,3 +16,4 @@ serde = { version = "1", optional = true }
 passkey-types = { version = "0.1", optional = true }
 serde_json = { version = "1", optional = true }
 coset = { version = "0.3", optional = true }
+multihash = { version = "0.18", optional = true }

--- a/varsig/Cargo.toml
+++ b/varsig/Cargo.toml
@@ -5,10 +5,13 @@ edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]
-default = ["serde"]
+default = ["serde", "webauthn"]
+webauthn = ["serde", "dep:passkey-types", "dep:serde_json"]
 serde = ["dep:serde"]
 
 [dependencies]
 unsigned-varint = { version = "0.7", features = ["std"] }
 thiserror = "1"
 serde = { version = "1", optional = true }
+passkey-types = { version = "0.1", optional = true }
+serde_json = { version = "1", optional = true }

--- a/varsig/Cargo.toml
+++ b/varsig/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]
 default = ["serde", "webauthn"]
-webauthn = ["serde", "dep:passkey-types", "dep:serde_json"]
+webauthn = ["serde", "dep:passkey-types", "dep:serde_json", "dep:coset"]
 serde = ["dep:serde"]
 
 [dependencies]
@@ -15,3 +15,4 @@ thiserror = "1"
 serde = { version = "1", optional = true }
 passkey-types = { version = "0.1", optional = true }
 serde_json = { version = "1", optional = true }
+coset = { version = "0.3", optional = true }

--- a/varsig/src/common/mod.rs
+++ b/varsig/src/common/mod.rs
@@ -73,6 +73,19 @@ pub enum JoseSig<const E: u64> {
     Es256K(Es256K<E>),
 }
 
+impl<const E: u64> JoseSig<E> {
+    pub fn bytes(&self) -> &[u8] {
+        match self {
+            JoseSig::Es256(sig) => sig.bytes(),
+            JoseSig::Es512(sig) => sig.bytes(),
+            JoseSig::Rsa256(sig) => sig.bytes(),
+            JoseSig::Rsa512(sig) => sig.bytes(),
+            JoseSig::EdDSA(sig) => sig.bytes(),
+            JoseSig::Es256K(sig) => sig.bytes(),
+        }
+    }
+}
+
 impl<const E: u64> VarSigTrait for JoseSig<E> {
     type SerError = std::convert::Infallible;
     type DeserError = JoseError<E>;

--- a/varsig/src/common/mod.rs
+++ b/varsig/src/common/mod.rs
@@ -4,6 +4,8 @@ use std::io::{Read, Write};
 pub mod ecdsa;
 pub mod ed25519;
 pub mod rsa;
+#[cfg(feature = "webauthn")]
+pub mod webauthn;
 
 const SHA256: u16 = 0x12;
 const SHA512: u16 = 0x13;
@@ -18,6 +20,9 @@ pub const DAG_CBOR_ENCODING: u64 = 0x71;
 pub use ecdsa::{EcdsaError, Eip191, Es256, Es256K, Es512, Ethereum};
 pub use ed25519::{Ed25519, Ed25519Error};
 pub use rsa::{Rsa256, Rsa512, RsaError};
+
+#[cfg(feature = "webauthn")]
+pub use webauthn::PasskeySig;
 
 #[derive(thiserror::Error, Debug)]
 pub enum JoseError<const ENCODING: u64> {

--- a/varsig/src/common/webauthn.rs
+++ b/varsig/src/common/webauthn.rs
@@ -1,5 +1,9 @@
 use crate::{DeserError, SerError, VarSigTrait};
-pub use passkey_types::{ctap2::AuthenticatorData, webauthn::CollectedClientData};
+pub use passkey_types::{
+    ctap2::AuthenticatorData,
+    encoding::{base64url, try_from_base64url},
+    webauthn::CollectedClientData,
+};
 use std::io::{Read, Write};
 use unsigned_varint::{
     encode::{u64 as write_u64, u64_buffer},

--- a/varsig/src/common/webauthn.rs
+++ b/varsig/src/common/webauthn.rs
@@ -29,7 +29,7 @@ pub mod generic {
         io::read_u64,
     };
 
-    #[derive(Clone, Debug, PartialEq)]
+    #[derive(Clone, Debug, PartialEq, Eq, Hash)]
     pub struct PasskeySig<S> {
         client_data: Vec<u8>,
         authenticator_data: Vec<u8>,

--- a/varsig/src/common/webauthn.rs
+++ b/varsig/src/common/webauthn.rs
@@ -1,215 +1,155 @@
-use crate::{DeserError, SerError, VarSigTrait};
-pub use passkey_types::{
-    ctap2::AuthenticatorData,
-    encoding::{base64url, try_from_base64url},
-    webauthn::CollectedClientData,
-};
-use std::io::{Read, Write};
-use unsigned_varint::{
-    encode::{u64 as write_u64, u64_buffer},
-    io::read_u64,
-};
+use super::{JoseError, JoseSig};
 
 pub const WEBAUTHN: u16 = 0x6672;
+pub type PasskeySig<const E: u64> = generic::PasskeySig<JoseSig<E>>;
+pub type Error<const E: u64> = generic::Error<JoseError<E>>;
 
-#[derive(Clone, Debug, PartialEq)]
-pub struct AssertionSigData {
-    client_data: Vec<u8>,
-    authenticator_data: Vec<u8>,
-    signature: Vec<u8>,
-}
+pub mod generic {
+    use crate::{DeserError, SerError, VarSigTrait};
+    pub use passkey_types::{
+        ctap2::AuthenticatorData,
+        encoding::{base64url, try_from_base64url},
+        webauthn::CollectedClientData,
+    };
+    use std::io::{Read, Write};
+    use unsigned_varint::{
+        encode::{u64 as write_u64, u64_buffer},
+        io::read_u64,
+    };
 
-#[derive(Clone, Debug, PartialEq)]
-pub struct PasskeySig<const ENCODING: u64> {
-    assertion: AssertionSigData,
-}
-
-impl AssertionSigData {
-    pub fn new(
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct PasskeySig<S> {
         client_data: Vec<u8>,
         authenticator_data: Vec<u8>,
-        signature: Vec<u8>,
-    ) -> AssertionSigData {
-        AssertionSigData {
-            client_data,
-            authenticator_data,
-            signature,
+        signature: S,
+    }
+
+    impl<S> PasskeySig<S> {
+        pub fn new(
+            client_data: Vec<u8>,
+            authenticator_data: Vec<u8>,
+            signature: S,
+        ) -> PasskeySig<S> {
+            PasskeySig {
+                client_data,
+                authenticator_data,
+                signature,
+            }
+        }
+
+        pub fn client_data(&self) -> &[u8] {
+            &self.client_data
+        }
+        pub fn parse_client_data(&self) -> Result<CollectedClientData, serde_json::Error> {
+            serde_json::from_slice(&self.client_data)
+        }
+        pub fn authenticator_data(&self) -> &[u8] {
+            &self.authenticator_data
+        }
+        pub fn parse_authenticator_data(&self) -> Result<AuthenticatorData, coset::CoseError> {
+            AuthenticatorData::from_slice(&self.client_data)
+        }
+        pub fn signature(&self) -> &S {
+            &self.signature
         }
     }
 
-    pub fn client_data(&self) -> &[u8] {
-        &self.client_data
-    }
-    pub fn parse_client_data(&self) -> Result<CollectedClientData, serde_json::Error> {
-        serde_json::from_slice(&self.client_data)
-    }
-    pub fn authenticator_data(&self) -> &[u8] {
-        &self.authenticator_data
-    }
-    pub fn parse_authenticator_data(&self) -> Result<AuthenticatorData, Error> {
-        AuthenticatorData::from_slice(&self.client_data)
-            .map_err(|_| Error::InvalidAuthenticatorData)
-    }
-    pub fn signature(&self) -> &[u8] {
-        &self.signature
-    }
-}
-
-impl<const E: u64> AsRef<AssertionSigData> for PasskeySig<E> {
-    fn as_ref(&self) -> &AssertionSigData {
-        &self.assertion
-    }
-}
-
-impl<const E: u64> PasskeySig<E> {
-    pub fn new(assertion: AssertionSigData) -> Self {
-        Self { assertion }
+    #[derive(thiserror::Error, Debug)]
+    pub enum Error<E: std::error::Error> {
+        #[error(transparent)]
+        Varint(#[from] unsigned_varint::decode::Error),
+        #[error("Invalid Collected Client Data: {0}")]
+        InvalidClientData(#[from] serde_json::Error),
+        #[error("Invalid Authenticator Data: {0}")]
+        InvalidAuthenticatorData(coset::CoseError),
+        #[error(transparent)]
+        Signature(E),
     }
 
-    pub fn into_inner(self) -> AssertionSigData {
-        self.assertion
-    }
-}
-
-#[derive(thiserror::Error, Debug)]
-pub enum Error {
-    #[error(transparent)]
-    Varint(#[from] unsigned_varint::decode::Error),
-    #[error("Invalid Collected Client Data")]
-    InvalidClientData,
-    #[error("Invalid Authenticator Data")]
-    InvalidAuthenticatorData,
-    #[error("Signature does not match Authenticator Data")]
-    SignatureMismatch,
-    #[error("Unsupported Cose Algorithm")]
-    UnsupportedAlg,
-}
-
-#[derive(thiserror::Error, Debug)]
-pub enum EncodingErr<const E: u64> {
-    #[error(transparent)]
-    Other(#[from] Error),
-    #[error("Expected {E}, got {0}")]
-    Encoding(u64),
-}
-
-impl<const E: u64> From<unsigned_varint::decode::Error> for EncodingErr<E> {
-    fn from(e: unsigned_varint::decode::Error) -> Self {
-        Self::Other(e.into())
-    }
-}
-
-impl VarSigTrait for AssertionSigData {
-    type SerError = std::convert::Infallible;
-    type DeserError = Error;
-
-    fn valid_header(bytes: &[u8]) -> bool {
-        let mut buf = u64_buffer();
-        let h = write_u64(WEBAUTHN as u64, &mut buf);
-        Some(h) == bytes.get(..2)
-    }
-
-    fn from_reader<R>(mut reader: R) -> Result<Self, DeserError<Self::DeserError>>
+    impl<E> From<coset::CoseError> for Error<E>
     where
-        R: Read,
+        E: std::error::Error,
     {
-        let client_data = read_some(&mut reader)?;
-
-        let buf = read_some(&mut reader)?;
-        AuthenticatorData::from_slice(&buf)
-            .map_err(|_| DeserError::Format(Error::InvalidAuthenticatorData))?;
-
-        let signature = read_some(&mut reader)?;
-
-        Ok(Self {
-            client_data,
-            authenticator_data: buf,
-            signature,
-        })
+        fn from(e: coset::CoseError) -> Self {
+            Error::InvalidAuthenticatorData(e)
+        }
     }
 
-    fn to_writer<W>(&self, mut writer: W) -> Result<(), SerError<Self::SerError>>
+    impl<S> VarSigTrait for PasskeySig<S>
     where
-        W: Write,
+        S: VarSigTrait,
     {
-        let mut buf = u64_buffer();
+        type SerError = S::SerError;
+        type DeserError = Error<S::DeserError>;
 
-        writer.write_all(write_u64(self.client_data.len() as u64, &mut buf))?;
-        writer.write_all(&self.client_data).map_err(SerError::Io)?;
-
-        self.authenticator_data.to_vec();
-        writer.write_all(write_u64(self.authenticator_data.len() as u64, &mut buf))?;
-        writer
-            .write_all(&self.authenticator_data)
-            .map_err(SerError::Io)?;
-
-        writer.write_all(write_u64(self.signature.len() as u64, &mut buf))?;
-        writer.write_all(&self.signature)?;
-        Ok(())
-    }
-
-    fn from_bytes(bytes: &[u8]) -> Result<Self, DeserError<Self::DeserError>>
-    where
-        Self: Sized,
-    {
-        let mut reader = std::io::Cursor::new(bytes);
-        Self::from_reader(&mut reader)
-    }
-}
-
-impl<const E: u64> VarSigTrait for PasskeySig<E> {
-    type SerError = std::convert::Infallible;
-    type DeserError = EncodingErr<E>;
-
-    fn valid_header(bytes: &[u8]) -> bool {
-        let mut buf = u64_buffer();
-        let h = write_u64(WEBAUTHN as u64, &mut buf);
-        Some(h) == bytes.get(..2)
-    }
-
-    fn from_reader<R>(mut reader: R) -> Result<Self, DeserError<Self::DeserError>>
-    where
-        R: Read,
-    {
-        let encoding = read_u64(&mut reader)?;
-        if encoding != E {
-            return Err(DeserError::Format(EncodingErr::Encoding(encoding)));
+        fn valid_header(bytes: &[u8]) -> bool {
+            let mut buf = u64_buffer();
+            let h = write_u64(super::WEBAUTHN as u64, &mut buf);
+            Some(h) == bytes.get(..2)
         }
 
-        let assertion = AssertionSigData::from_reader(&mut reader).map_err(|e| match e {
-            DeserError::Format(f) => DeserError::Format(EncodingErr::Other(f)),
-            DeserError::Io(e) => DeserError::Io(e),
-            DeserError::InvalidHeader => DeserError::InvalidHeader,
-        })?;
-        Ok(Self { assertion })
+        fn from_reader<R>(mut reader: R) -> Result<Self, DeserError<Self::DeserError>>
+        where
+            R: Read,
+        {
+            if read_u64(&mut reader)? != super::WEBAUTHN as u64 {
+                return Err(DeserError::InvalidHeader);
+            };
+
+            let client_data = read_some(&mut reader)?;
+
+            let buf = read_some(&mut reader)?;
+            AuthenticatorData::from_slice(&buf).map_err(|e| DeserError::Format(e.into()))?;
+
+            let signature = S::from_reader(&mut reader).map_err(|e| match e {
+                DeserError::Format(e) => DeserError::Format(Error::Signature(e)),
+                DeserError::Io(e) => DeserError::Io(e),
+                DeserError::InvalidHeader => DeserError::InvalidHeader,
+            })?;
+
+            Ok(Self {
+                client_data,
+                authenticator_data: buf,
+                signature,
+            })
+        }
+
+        fn to_writer<W>(&self, mut writer: W) -> Result<(), SerError<Self::SerError>>
+        where
+            W: Write,
+        {
+            let mut buf = u64_buffer();
+
+            writer.write_all(write_u64(super::WEBAUTHN as u64, &mut buf))?;
+            writer.write_all(write_u64(self.client_data.len() as u64, &mut buf))?;
+            writer.write_all(&self.client_data).map_err(SerError::Io)?;
+
+            self.authenticator_data.to_vec();
+            writer.write_all(write_u64(self.authenticator_data.len() as u64, &mut buf))?;
+            writer
+                .write_all(&self.authenticator_data)
+                .map_err(SerError::Io)?;
+
+            self.signature.to_writer(&mut writer)?;
+            Ok(())
+        }
+
+        fn from_bytes(bytes: &[u8]) -> Result<Self, DeserError<Self::DeserError>>
+        where
+            Self: Sized,
+        {
+            let mut reader = std::io::Cursor::new(bytes);
+            Self::from_reader(&mut reader)
+        }
     }
 
-    fn to_writer<W>(&self, mut writer: W) -> Result<(), SerError<Self::SerError>>
+    fn read_some<R>(reader: &mut R) -> Result<Vec<u8>, unsigned_varint::io::ReadError>
     where
-        W: Write,
+        R: Read,
     {
-        let mut buf = u64_buffer();
-        writer.write_all(write_u64(E, &mut buf))?;
-
-        self.assertion.to_writer(&mut writer)?;
-        Ok(())
+        let len = read_u64(reader.by_ref())?;
+        let mut buf = vec![0; len as usize];
+        reader.read_exact(&mut buf)?;
+        Ok(buf)
     }
-
-    fn from_bytes(bytes: &[u8]) -> Result<Self, DeserError<Self::DeserError>>
-    where
-        Self: Sized,
-    {
-        let mut reader = std::io::Cursor::new(bytes);
-        Self::from_reader(&mut reader)
-    }
-}
-
-fn read_some<R>(reader: &mut R) -> Result<Vec<u8>, DeserError<Error>>
-where
-    R: Read,
-{
-    let len = read_u64(reader.by_ref())?;
-    let mut buf = vec![0; len as usize];
-    reader.read_exact(&mut buf)?;
-    Ok(buf)
 }

--- a/varsig/src/common/webauthn.rs
+++ b/varsig/src/common/webauthn.rs
@@ -173,7 +173,7 @@ impl<const E: u64> VarSigTrait for PasskeySig<E> {
     {
         let encoding = read_u64(&mut reader)?;
         if encoding != E {
-            return Err(DeserError::Format(EncodingErr::Encoding(encoding).into()));
+            return Err(DeserError::Format(EncodingErr::Encoding(encoding)));
         }
 
         let assertion = AssertionSigData::from_reader(&mut reader).map_err(|e| match e {

--- a/varsig/src/common/webauthn.rs
+++ b/varsig/src/common/webauthn.rs
@@ -1,0 +1,211 @@
+use crate::{DeserError, SerError, VarSigTrait};
+pub use passkey_types::{ctap2::AuthenticatorData, webauthn::CollectedClientData};
+use std::io::{Read, Write};
+use unsigned_varint::{
+    encode::{u64 as write_u64, u64_buffer},
+    io::read_u64,
+};
+
+pub const WEBAUTHN: u16 = 0x6672;
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct AssertionSigData {
+    client_data: Vec<u8>,
+    authenticator_data: Vec<u8>,
+    signature: Vec<u8>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct PasskeySig<const ENCODING: u64> {
+    assertion: AssertionSigData,
+}
+
+impl AssertionSigData {
+    pub fn new(
+        client_data: Vec<u8>,
+        authenticator_data: Vec<u8>,
+        signature: Vec<u8>,
+    ) -> AssertionSigData {
+        AssertionSigData {
+            client_data,
+            authenticator_data,
+            signature,
+        }
+    }
+
+    pub fn client_data(&self) -> &[u8] {
+        &self.client_data
+    }
+    pub fn parse_client_data(&self) -> Result<CollectedClientData, serde_json::Error> {
+        serde_json::from_slice(&self.client_data)
+    }
+    pub fn authenticator_data(&self) -> &[u8] {
+        &self.authenticator_data
+    }
+    pub fn parse_authenticator_data(&self) -> Result<AuthenticatorData, Error> {
+        AuthenticatorData::from_slice(&self.client_data)
+            .map_err(|_| Error::InvalidAuthenticatorData)
+    }
+    pub fn signature(&self) -> &[u8] {
+        &self.signature
+    }
+}
+
+impl<const E: u64> AsRef<AssertionSigData> for PasskeySig<E> {
+    fn as_ref(&self) -> &AssertionSigData {
+        &self.assertion
+    }
+}
+
+impl<const E: u64> PasskeySig<E> {
+    pub fn new(assertion: AssertionSigData) -> Self {
+        Self { assertion }
+    }
+
+    pub fn into_inner(self) -> AssertionSigData {
+        self.assertion
+    }
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error(transparent)]
+    Varint(#[from] unsigned_varint::decode::Error),
+    #[error("Invalid Collected Client Data")]
+    InvalidClientData,
+    #[error("Invalid Authenticator Data")]
+    InvalidAuthenticatorData,
+    #[error("Signature does not match Authenticator Data")]
+    SignatureMismatch,
+    #[error("Unsupported Cose Algorithm")]
+    UnsupportedAlg,
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum EncodingErr<const E: u64> {
+    #[error(transparent)]
+    Other(#[from] Error),
+    #[error("Expected {E}, got {0}")]
+    Encoding(u64),
+}
+
+impl<const E: u64> From<unsigned_varint::decode::Error> for EncodingErr<E> {
+    fn from(e: unsigned_varint::decode::Error) -> Self {
+        Self::Other(e.into())
+    }
+}
+
+impl VarSigTrait for AssertionSigData {
+    type SerError = std::convert::Infallible;
+    type DeserError = Error;
+
+    fn valid_header(bytes: &[u8]) -> bool {
+        let mut buf = u64_buffer();
+        let h = write_u64(WEBAUTHN as u64, &mut buf);
+        Some(h) == bytes.get(..2)
+    }
+
+    fn from_reader<R>(mut reader: R) -> Result<Self, DeserError<Self::DeserError>>
+    where
+        R: Read,
+    {
+        let client_data = read_some(&mut reader)?;
+
+        let buf = read_some(&mut reader)?;
+        AuthenticatorData::from_slice(&buf)
+            .map_err(|_| DeserError::Format(Error::InvalidAuthenticatorData))?;
+
+        let signature = read_some(&mut reader)?;
+
+        Ok(Self {
+            client_data,
+            authenticator_data: buf,
+            signature,
+        })
+    }
+
+    fn to_writer<W>(&self, mut writer: W) -> Result<(), SerError<Self::SerError>>
+    where
+        W: Write,
+    {
+        let mut buf = u64_buffer();
+
+        writer.write_all(write_u64(self.client_data.len() as u64, &mut buf))?;
+        writer.write_all(&self.client_data).map_err(SerError::Io)?;
+
+        self.authenticator_data.to_vec();
+        writer.write_all(write_u64(self.authenticator_data.len() as u64, &mut buf))?;
+        writer
+            .write_all(&self.authenticator_data)
+            .map_err(SerError::Io)?;
+
+        writer.write_all(write_u64(self.signature.len() as u64, &mut buf))?;
+        writer.write_all(&self.signature)?;
+        Ok(())
+    }
+
+    fn from_bytes(bytes: &[u8]) -> Result<Self, DeserError<Self::DeserError>>
+    where
+        Self: Sized,
+    {
+        let mut reader = std::io::Cursor::new(bytes);
+        Self::from_reader(&mut reader)
+    }
+}
+
+impl<const E: u64> VarSigTrait for PasskeySig<E> {
+    type SerError = std::convert::Infallible;
+    type DeserError = EncodingErr<E>;
+
+    fn valid_header(bytes: &[u8]) -> bool {
+        let mut buf = u64_buffer();
+        let h = write_u64(WEBAUTHN as u64, &mut buf);
+        Some(h) == bytes.get(..2)
+    }
+
+    fn from_reader<R>(mut reader: R) -> Result<Self, DeserError<Self::DeserError>>
+    where
+        R: Read,
+    {
+        let encoding = read_u64(&mut reader)?;
+        if encoding != E {
+            return Err(DeserError::Format(EncodingErr::Encoding(encoding).into()));
+        }
+
+        let assertion = AssertionSigData::from_reader(&mut reader).map_err(|e| match e {
+            DeserError::Format(f) => DeserError::Format(EncodingErr::Other(f)),
+            DeserError::Io(e) => DeserError::Io(e),
+            DeserError::InvalidHeader => DeserError::InvalidHeader,
+        })?;
+        Ok(Self { assertion })
+    }
+
+    fn to_writer<W>(&self, mut writer: W) -> Result<(), SerError<Self::SerError>>
+    where
+        W: Write,
+    {
+        let mut buf = u64_buffer();
+        writer.write_all(write_u64(E, &mut buf))?;
+
+        self.assertion.to_writer(&mut writer)?;
+        Ok(())
+    }
+
+    fn from_bytes(bytes: &[u8]) -> Result<Self, DeserError<Self::DeserError>>
+    where
+        Self: Sized,
+    {
+        let mut reader = std::io::Cursor::new(bytes);
+        Self::from_reader(&mut reader)
+    }
+}
+
+fn read_some<R>(reader: &mut R) -> Result<Vec<u8>, DeserError<Error>>
+where
+    R: Read,
+{
+    let len = read_u64(reader.by_ref())?;
+    let mut buf = vec![0; len as usize];
+    reader.read_exact(&mut buf)?;
+    Ok(buf)
+}


### PR DESCRIPTION
Implements a VarSig type for signatures made using webauthn. The Varsig carries the serialised Collected Client Data, Authenticator Data and generated Signature, all the outputs from webauthn which are required to verify the signature. Based on the 1Password passkey-types crate.